### PR TITLE
Editorial: Set 'Level: none' in Bikeshed metadata

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,7 +1,7 @@
 <pre class='metadata'>
 Title: Post-Spectre Web Development
 Shortname: post-spectre-webdev
-Level: 1
+Level: none
 Status: ED
 Group: WebAppSec
 ED: https://w3c.github.io/webappsec-post-spectre-webdev/


### PR DESCRIPTION
See https://tabatkins.github.io/bikeshed/#metadata-level —

> Level (or Revision, an alias) must contain the spec’s level as an integer or `none` if the spec does not use levels.

So we want `none` here, because we’re not versioning this document.

And otherwise, without this change, running Bikeshed fails with:

> FATAL ERROR: While trying to generate a Previous Version line, couldn't find a dated biblio reference for post-spectre-webdev-1.

... and that happens because we published the TR version here:

https://www.w3.org/TR/post-spectre-webdev/

... rather than here:

https://www.w3.org/TR/post-spectre-webdev-1/